### PR TITLE
Add AIDAC-SCAN prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# test_test
+# AIDAC-SCAN
+
+A minimal prototype CLI that clones a GitHub repository, builds a conda environment using `micromamba`, runs a smoke test, and produces a reproducibility report.
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## Usage
+
+```bash
+aidac-scan <repo-url> --output my_report
+```
+
+The tool will generate `report.md` and `report.json` inside the output directory.

--- a/aidac_scan/__init__.py
+++ b/aidac_scan/__init__.py
@@ -1,0 +1,4 @@
+"""Top-level package for AIDAC-SCAN."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/aidac_scan/builder.py
+++ b/aidac_scan/builder.py
@@ -1,0 +1,103 @@
+"""Utilities for building and testing repositories in isolated environments."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Tuple
+
+from git import Repo
+
+
+def clone_repo(url: str, dest: Path | None = None) -> Path:
+    """Clone the git repository into a temporary directory."""
+    dest = dest or Path(tempfile.mkdtemp(prefix="aidac_repo_"))
+    Repo.clone_from(url, dest)
+    return dest
+
+
+def repo_info(path: Path) -> Tuple[str, str]:
+    """Return repository name and current commit hash."""
+    repo = Repo(path)
+    return Path(repo.working_dir).name, repo.head.commit.hexsha
+
+
+def generate_env_yaml(repo_path: Path) -> str:
+    """Generate a simple conda environment YAML from requirements.txt."""
+    req = repo_path / "requirements.txt"
+    lines = [
+        "name: aidac_env",
+        "channels:",
+        "  - conda-forge",
+        "dependencies:",
+        "  - python=3.10",
+        "  - pip",
+    ]
+    if req.exists():
+        lines.append("  - pip:")
+        lines.append("      - -r requirements.txt")
+    return "\n".join(lines) + "\n"
+
+
+def build_environment(env_yaml: str, repo_path: Path) -> Tuple[bool, str, float, str]:
+    """Create the environment and install the repo."""
+    env_file = repo_path / "env_generated.yaml"
+    env_file.write_text(env_yaml)
+    env_name = f"aidac_env_{int(time.time())}"
+    start = time.time()
+    try:
+        create_proc = subprocess.run(
+            ["micromamba", "create", "-y", "-n", env_name, "-f", str(env_file)],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as e:
+        return False, str(e), time.time() - start, env_name
+    logs = create_proc.stdout + create_proc.stderr
+    if create_proc.returncode != 0:
+        return False, logs, time.time() - start, env_name
+
+    install_proc = subprocess.run(
+        ["micromamba", "run", "-n", env_name, "pip", "install", "-e", "."],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    logs += install_proc.stdout + install_proc.stderr
+    success = install_proc.returncode == 0
+    return success, logs, time.time() - start, env_name
+
+
+def run_smoke_test(env_name: str, repo_path: Path) -> Tuple[bool, str]:
+    """Run pytest if tests exist, otherwise pip list."""
+    tests_exist = (repo_path / "tests").exists()
+    if tests_exist:
+        cmd = [
+            "micromamba",
+            "run",
+            "-n",
+            env_name,
+            "python",
+            "-m",
+            "pytest",
+            "-q",
+        ]
+    else:
+        cmd = [
+            "micromamba",
+            "run",
+            "-n",
+            env_name,
+            "python",
+            "-m",
+            "pip",
+            "list",
+        ]
+    try:
+        proc = subprocess.run(cmd, cwd=repo_path, capture_output=True, text=True)
+        log = proc.stdout + proc.stderr
+        return proc.returncode == 0, log
+    except FileNotFoundError as e:
+        return False, str(e)

--- a/aidac_scan/cli.py
+++ b/aidac_scan/cli.py
@@ -1,0 +1,78 @@
+"""Command line interface for AIDAC-SCAN."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from rich.progress import Progress
+
+from aidac_scan.builder import (
+    build_environment,
+    clone_repo,
+    generate_env_yaml,
+    repo_info,
+    run_smoke_test,
+)
+from aidac_scan.report import BuildReport, write_report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run AIDAC-SCAN on a repo")
+    parser.add_argument("repo", help="Git repository URL")
+    parser.add_argument(
+        "--dataset", help="Optional dataset path", default=None
+    )
+    parser.add_argument(
+        "--output", help="Output directory for report", default="aidac_output"
+    )
+    args = parser.parse_args(argv)
+
+    repo_path = clone_repo(args.repo)
+    name, commit = repo_info(repo_path)
+    env_yaml = generate_env_yaml(repo_path)
+
+    with Progress() as progress:
+        task = progress.add_task("Building environment", total=None)
+        success, logs, duration, env_name = build_environment(env_yaml, repo_path)
+        progress.remove_task(task)
+
+    log_tail = "\n".join(logs.strip().splitlines()[-50:]) if not success else ""
+    if not success:
+        log_dir = Path(args.output) / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (log_dir / "build_fail.log").write_text(log_tail)
+        write_report(
+            BuildReport(
+                repo_name=name,
+                commit=commit,
+                build_success=False,
+                smoke_success=False,
+                build_time=duration,
+                env_yaml=env_yaml,
+                log_tail=log_tail,
+            ),
+            Path(args.output),
+        )
+        return 1
+
+    smoke_success, smoke_log = run_smoke_test(env_name, repo_path)
+
+    write_report(
+        BuildReport(
+            repo_name=name,
+            commit=commit,
+            build_success=True,
+            smoke_success=smoke_success,
+            build_time=duration,
+            env_yaml=env_yaml,
+            log_tail="" if smoke_success else smoke_log.splitlines()[-50:],
+        ),
+        Path(args.output),
+    )
+    return 0 if smoke_success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/aidac_scan/report.py
+++ b/aidac_scan/report.py
@@ -1,0 +1,59 @@
+"""Functions for generating Markdown and JSON reports."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+from jinja2 import Template
+
+
+@dataclass
+class BuildReport:
+    repo_name: str
+    commit: str
+    build_success: bool
+    smoke_success: bool
+    build_time: float
+    env_yaml: str
+    log_tail: str
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "repo_name": self.repo_name,
+            "commit": self.commit,
+            "build_success": self.build_success,
+            "smoke_success": self.smoke_success,
+            "build_time": self.build_time,
+            "env_yaml": self.env_yaml,
+            "log_tail": self.log_tail,
+        }
+
+
+MD_TEMPLATE = Template(
+    """# AIDAC-SCAN Report for {{ repo_name }}@{{ commit }}
+
+- **Build success**: {{ build_success }}
+- **Smoke-test success**: {{ smoke_success }}
+- **Build time (s)**: {{ build_time }}
+
+## Environment
+```yaml
+{{ env_yaml }}
+```
+{% if log_tail %}
+## Log tail
+```
+{{ log_tail }}
+```
+{% endif %}
+"""
+)
+
+
+def write_report(report: BuildReport, out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "report.json").write_text(json.dumps(report.as_dict(), indent=2))
+    (out_dir / "report.md").write_text(MD_TEMPLATE.render(**report.as_dict()))

--- a/example_reports/cellpose/logs/build_fail.log
+++ b/example_reports/cellpose/logs/build_fail.log
@@ -1,0 +1,1 @@
+[Errno 2] No such file or directory: 'micromamba'

--- a/example_reports/cellpose/report.json
+++ b/example_reports/cellpose/report.json
@@ -1,0 +1,9 @@
+{
+  "repo_name": "aidac_repo_h_ja4r5i",
+  "commit": "79b0fcbf0296af8b021bcb812ff768d3e90aeb5d",
+  "build_success": false,
+  "smoke_success": false,
+  "build_time": 0.005076169967651367,
+  "env_yaml": "name: aidac_env\nchannels:\n  - conda-forge\ndependencies:\n  - python=3.10\n  - pip\n",
+  "log_tail": "[Errno 2] No such file or directory: 'micromamba'"
+}

--- a/example_reports/cellpose/report.md
+++ b/example_reports/cellpose/report.md
@@ -1,0 +1,21 @@
+# AIDAC-SCAN Report for aidac_repo_h_ja4r5i@79b0fcbf0296af8b021bcb812ff768d3e90aeb5d
+
+- **Build success**: False
+- **Smoke-test success**: False
+- **Build time (s)**: 0.005076169967651367
+
+## Environment
+```yaml
+name: aidac_env
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - pip
+
+```
+
+## Log tail
+```
+[Errno 2] No such file or directory: 'micromamba'
+```

--- a/example_reports/pytorch_fnet/logs/build_fail.log
+++ b/example_reports/pytorch_fnet/logs/build_fail.log
@@ -1,0 +1,1 @@
+[Errno 2] No such file or directory: 'micromamba'

--- a/example_reports/pytorch_fnet/report.json
+++ b/example_reports/pytorch_fnet/report.json
@@ -1,0 +1,9 @@
+{
+  "repo_name": "aidac_repo_38i6tkuh",
+  "commit": "64c53d123df644cebe5e4f7f2ab6efc5c0732f4e",
+  "build_success": false,
+  "smoke_success": false,
+  "build_time": 0.01383519172668457,
+  "env_yaml": "name: aidac_env\nchannels:\n  - conda-forge\ndependencies:\n  - python=3.10\n  - pip\n",
+  "log_tail": "[Errno 2] No such file or directory: 'micromamba'"
+}

--- a/example_reports/pytorch_fnet/report.md
+++ b/example_reports/pytorch_fnet/report.md
@@ -1,0 +1,21 @@
+# AIDAC-SCAN Report for aidac_repo_38i6tkuh@64c53d123df644cebe5e4f7f2ab6efc5c0732f4e
+
+- **Build success**: False
+- **Smoke-test success**: False
+- **Build time (s)**: 0.01383519172668457
+
+## Environment
+```yaml
+name: aidac_env
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - pip
+
+```
+
+## Log tail
+```
+[Errno 2] No such file or directory: 'micromamba'
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "aidac-scan"
+version = "0.1.0"
+description = "AI-assisted auditing CLI"
+authors = [{name="Codex", email="codex@example.com"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "rich",
+    "GitPython",
+    "pyyaml",
+    "jinja2",
+]
+
+[project.scripts]
+aidac-scan = "aidac_scan.cli:main"
+
+[tool.setuptools.packages.find]
+exclude = ["example_reports"]


### PR DESCRIPTION
## Summary
- implement AIDAC-SCAN builder, CLI and report generator
- provide packaging via `pyproject.toml`
- include example reports for `pytorch_fnet` and `cellpose`
- update README with basic usage

## Testing
- `pip install -e .`
- `aidac-scan https://github.com/AllenCellModeling/pytorch_fnet.git --output example_reports/pytorch_fnet` *(fails: micromamba missing)*
- `aidac-scan https://github.com/MouseLand/cellpose.git --output example_reports/cellpose` *(fails: micromamba missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845d3e065908327be80280b0a642cd2